### PR TITLE
Fixing sulfuric-acid-geyser masking in biter territory. It was using …

### DIFF
--- a/map-generation/noise-visualization.lua
+++ b/map-generation/noise-visualization.lua
@@ -4,7 +4,7 @@ end
 
 local noise_debug = require '__noise-tools__/noise-debug'
 
-noise_debug.remove_non_tile_autoplace()
+-- noise_debug.remove_non_tile_autoplace()
 noise_debug.hide_map_cliffs()
 noise_debug.tiles_to_visualisation('visualisation', -1, 2, '3-band')
 
@@ -16,8 +16,33 @@ noise_debug.add_visualisation_target('vulcanus_calcite_region', nil, 1)
 noise_debug.add_visualisation_target('vulcanus_calcite_probability', nil, 1)
 noise_debug.add_visualisation_target('vulcanus_calcite_richness', nil, 1)
 
+noise_debug.add_visualisation_target("sulfuric_acid_probability_masked", data.raw["resource"]["sulfuric-acid-geyser"].autoplace.probability_expression,  1)
 noise_debug.add_visualisation_target('vulcanus_sulfuric_acid_geyser_probability', nil, 1)
+noise_debug.add_visualisation_target('vulcanus_sulfuric_acid_geyser_richness', nil, 1)
 noise_debug.add_visualisation_target('vulcanus_tungsten_ore_probability', nil, 1)
 
 noise_debug.add_visualisation_target('vulcanus_sulfuric_acid_region', nil, 1)
 noise_debug.add_visualisation_target('vulcanus_tungsten_ore_region', nil, 1)
+
+noise_debug.add_visualisation_target("gleba_mask", nil, 1)
+noise_debug.add_visualisation_target("vulcanus_mask", nil, 1)
+noise_debug.add_visualisation_target("volcano_mask", nil, 1)
+noise_debug.add_visualisation_target("aquilo_mask", nil, 1)
+
+noise_debug.add_visualisation_target("mask_prevent_fixed", "mask_prevent_fixed{expression=1}", 1)
+noise_debug.add_visualisation_target("mask_prevent_biter", "mask_prevent_biter{expression=1}", 1)
+noise_debug.add_visualisation_target("mask_allow_aquilo", "mask_allow_aquilo{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_aquilo", "mask_prevent_aquilo{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_ammonia_ocean", "mask_allow_ammonia_ocean{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_ammonia_ocean", "mask_prevent_ammonia_ocean{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_volcano", "mask_allow_volcano{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_volcano", "mask_prevent_volcano{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_vulcanus", "mask_allow_vulcanus{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_vulcanus", "mask_prevent_vulcanus{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_volcano", "mask_allow_volcano{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_volcano", "mask_prevent_volcano{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_gleba", "mask_allow_gleba{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_prevent_gleba", "mask_prevent_gleba{expression=1}",  1)
+noise_debug.add_visualisation_target("mask_allow_nauvis_and_moat", "mask_allow_nauvis_and_moat{expression=1}",  1)
+noise_debug.add_visualisation_target("updated_water", nil,  1)
+noise_debug.add_visualisation_target("updated_deepwater", nil,  1)

--- a/map-generation/vulcanus.lua
+++ b/map-generation/vulcanus.lua
@@ -43,24 +43,22 @@ return function(terrain)
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["vulcanus-chimney-truncated"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["huge-volcanic-rock"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["big-volcanic-rock"] = {}
-
-
-            data.raw.planet["nauvis"].map_gen_settings.property_expression_names["entity:sulfuric-acid-geyser:probability"] =
-            "vulcanus_sulfuric_acid_geyser_probability"
-            data.raw.planet["nauvis"].map_gen_settings.property_expression_names["entity:sulfuric-acid-geyser:richness"] =
-            "vulcanus_sulfuric_acid_geyser_richness"
-
-            data.raw["autoplace-control"]["vulcanus_volcanism"].order = "z-volcanism"
-            data.raw["autoplace-control"]["vulcanus_volcanism"].localised_description = {
-                "autoplace-control-names.vulcanus_volcanism_description" }
-            data.raw["autoplace-control"]["vulcanus_volcanism"].category = "resource"
-            data.raw["autoplace-control"]["sulfuric_acid_geyser"].order = "b-z"
-
+            data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["sulfuric-acid-geyser"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["calcite"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["sulfuric-acid-geyser"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["tungsten-ore"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_settings.entity.settings["scrap"] = {}
             data.raw.planet["nauvis"].map_gen_settings.autoplace_controls["sulfuric_acid_geyser"] = {}
+
+            --- When masking is applied, the probability expression for sulfuric-acid-geysers will be set to a mask of default_sulfuric_acid_geyser            
+            data.raw["noise-expression"]["default_sulfuric_acid_geyser"].expression = "vulcanus_sulfuric_acid_geyser_probability"
+            data.raw["resource"]["sulfuric-acid-geyser"].autoplace.richness_expression = "vulcanus_sulfuric_acid_geyser_richness" 
+            
+            data.raw["autoplace-control"]["vulcanus_volcanism"].order = "z-volcanism"
+            data.raw["autoplace-control"]["vulcanus_volcanism"].localised_description = {
+                "autoplace-control-names.vulcanus_volcanism_description" }
+            data.raw["autoplace-control"]["vulcanus_volcanism"].category = "resource"
+            data.raw["autoplace-control"]["sulfuric_acid_geyser"].order = "b-z"
 
             data.raw["noise-expression"]["vulcanus_starting_calcite"].expression = "-inf"
             data.raw["noise-expression"]["vulcanus_calcite_probability"].expression =
@@ -159,7 +157,7 @@ return function(terrain)
                     -- Noise expression for vulcano spot and close surround as mask
                     type = "noise-expression",
                     name = "volcano_mask",
-                    expression = "max(updated_volcanic_folds, lava_mountains_range, lava_hot_mountains_range) > 0"
+                    expression = "mask_prevent_fixed(max(updated_volcanic_folds, lava_mountains_range, lava_hot_mountains_range) > 0)"
                 },
                 {
                     -- Noise expression for all vulcanus terrain as mask


### PR DESCRIPTION
…an independent expression which would not be caught by the default_ prototype generation that's applied after masking. Added visualization targets for masking.

- Add visualization targets for masking
- Mask the default_sulfuric_acid_geyser noise expression correctly
- Prevent fixed on volcano_mask